### PR TITLE
Implement addSecurityListenerFactory like suggested in issue #41

### DIFF
--- a/DependencyInjection/SecurityExtension.php
+++ b/DependencyInjection/SecurityExtension.php
@@ -19,6 +19,7 @@
 namespace JMS\SecurityExtraBundle\DependencyInjection;
 
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension as BaseSecurityExtension;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
@@ -39,6 +40,11 @@ class SecurityExtension extends Extension
     public function __construct(BaseSecurityExtension $extension)
     {
         $this->extension = $extension;
+    }
+
+    public function addSecurityListenerFactory(SecurityFactoryInterface $factory)
+    {
+        return $this->extension->addSecurityListenerFactory($factory);
     }
 
     public function getAlias()


### PR DESCRIPTION
You might think it's useless from the looks of it, but a BC break on Security Providers configuration may encourage bundle developers to check for that particular method.

See [this issue on FOSOAuthServerBundle](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/issues/12).
