### PR TITLE
made the di extension not doing anything if security is disabled

### DIFF
--- a/DependencyInjection/Compiler/CollectSecuredServicesPass.php
+++ b/DependencyInjection/Compiler/CollectSecuredServicesPass.php
@@ -30,6 +30,10 @@ class CollectSecuredServicesPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('security.access.pointcut')) {
+            return;
+        }
+
         $securedClasses = array();
         foreach ($container->findTaggedServiceIds('security.secure_service') as $id => $attr) {
             $securedClasses[] = $container->getDefinition($id)->getClass();

--- a/DependencyInjection/Compiler/DisableVotersPass.php
+++ b/DependencyInjection/Compiler/DisableVotersPass.php
@@ -25,6 +25,9 @@ class DisableVotersPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if ($container->hasParameter('jms_security_extra.disabled')) {
+            return;
+        }
         if ($container->getParameter('security.role_voter.disabled')) {
             $container->removeDefinition('security.access.role_hierarchy_voter');
             $container->removeDefinition('security.access.simple_role_voter');

--- a/DependencyInjection/Compiler/IntegrationPass.php
+++ b/DependencyInjection/Compiler/IntegrationPass.php
@@ -11,6 +11,9 @@ class IntegrationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if ($container->hasParameter('jms_security_extra.disabled')) {
+            return;
+        }
         if (!$container->hasAlias('security.acl.provider')
             && !$container->hasDefinition('security.acl.provider')) {
             $container->removeDefinition('security.acl.permission_evaluator');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ class Configuration implements ConfigurationInterface
         $tb = new TreeBuilder();
         $tb
             ->root('jms_security_extra')
+            ->canBeDisabled()
                 ->validate()
                     ->always(function($v) {
                         if ($v['method_access_control'] && !$v['expressions']) {

--- a/DependencyInjection/JMSSecurityExtraExtension.php
+++ b/DependencyInjection/JMSSecurityExtraExtension.php
@@ -41,6 +41,11 @@ class JMSSecurityExtraExtension extends Extension
         }
 
         $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
+        if (!$config['enabled']) {
+            $container->setParameter('jms_security_extra.disabled', true);
+
+            return;
+        }
 
         $loader = new XmlFileLoader($container, new FileLocator(array(__DIR__.'/../Resources/config/')));
         $loader->load('services.xml');


### PR DESCRIPTION
Hi,

This makes the di extension not doing anything if security is disabled. It's checking if security.context is defined, as apparently the security bundle should be registered before this one (https://github.com/schmittjoh/JMSSecurityExtraBundle/blob/master/JMSSecurityExtraBundle.php#L43).

cf : symfony/symfony#5908 and symfony/symfony-standard#434
