### PR TITLE
Changed IS_IDDQD to correct role ROLE_IDDQD

### DIFF
--- a/Resources/doc/configuration.rst
+++ b/Resources/doc/configuration.rst
@@ -13,7 +13,7 @@ Below, you find the default configuration:
             # services (false); see also below 
             secure_all_services: false
             
-            # Enabling this setting will add an additional special attribute "IS_IDDQD".
+            # Enabling this setting will add an additional special attribute "ROLE_IDDQD".
             # Anybody with this attribute will effectively bypass all security checks.
             enable_iddqd_attribute: false        
             


### PR DESCRIPTION
The default configuration reference for <code>enable_iddqd_attribute</code> is confusing about the role to be used: it says <code>IS_IDDQD</code> but in fact <code>ROLE_IDDQD</code> is used. 
