### PR TITLE
Removed the is_safe option on the Twig function

### DIFF
--- a/Twig/SecurityExtension.php
+++ b/Twig/SecurityExtension.php
@@ -17,9 +17,7 @@ class SecurityExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'is_expr_granted' => new \Twig_Function_Method($this, 'isExprGranted', array(
-                'is_safe' => true,
-            )),
+            'is_expr_granted' => new \Twig_Function_Method($this, 'isExprGranted'),
         );
     }
 


### PR DESCRIPTION
This function has no reason to be marked as safe, and marking
functions as safe should not be encouraged as being the common
practice for everything.
