### PR TITLE
Added classes to cache

### DIFF
--- a/DependencyInjection/JMSSecurityExtraExtension.php
+++ b/DependencyInjection/JMSSecurityExtraExtension.php
@@ -104,6 +104,17 @@ class JMSSecurityExtraExtension extends Extension
             $loader->load('security_secure_random.xml');
             $this->configureSecureRandom($config['util']['secure_random'], $container);
         }
+
+        $this->addClassesToCompile(array(
+            'JMS\\SecurityExtraBundle\\Security\\Authorization\\Expression\\ContainerAwareExpressionHandler',
+            'JMS\\SecurityExtraBundle\\Security\\Authorization\\Expression\\ExpressionHandlerInterface',
+            'JMS\\SecurityExtraBundle\\Security\\Authorization\\Expression\\ExpressionVoter',
+            'JMS\\SecurityExtraBundle\\Security\\Authorization\\Expression\\LazyLoadingExpressionVoter',
+            'JMS\\SecurityExtraBundle\\Security\\Authorization\\RememberingAccessDecisionManager',
+            /* This would introduce a hard dependency on Twig
+            'JMS\\SecurityExtraBundle\\Twig\\SecurityExtension',
+            */
+        ));
     }
 
     private function configureSecureRandom(array $config, ContainerBuilder $container)


### PR DESCRIPTION
Hello,

This commit adds some used classes to Symfony2 cache.
 See the talk in sensio/SensioDistributionBundle#76

Let me know if it needs anything else/if I've did it against the wrong branch (it should go into 2.2 distro).

Thanks.