### PR TITLE
Changed the Symfony requirements to allow 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "symfony/framework-bundle": ">=2.1.0,<2.3-dev",
+        "symfony/framework-bundle": "~2.1.0",
         "symfony/security-bundle": "*",
         "jms/metadata": "1.*",
         "jms/parser-lib": "1.*",


### PR DESCRIPTION
As we don't anticipate big changes in 2.3, I think it is safe to ope the requirements instead of creating a new branch.
