### PR TITLE
Added support for annotations in parent methods, when method is not over...

### DIFF
--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -55,7 +55,7 @@ class AnnotationDriver implements DriverInterface
         $classAnnotations = $this->reader->getClassAnnotations($reflection);
         foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED) as $method) {
             // check if the method was defined on this class
-            if ($method->getDeclaringClass()->name !== $reflection->name) {
+            if (($method->getDeclaringClass()->name !== $reflection->name) && (!$reflection->isSubclassOf($method->getDeclaringClass()->name))) {    
                 continue;
             }
 


### PR DESCRIPTION
...writted in current class

Example:

class A()
{

```
/**
 * Secure(roles="ROLE_AMIN")
 */
public function AA()
{
    echo 'engonga';
}
```

}

class B extends A
{

}

Previously, class B method AA() is not secure because main class of method is not the same as current class.
By adding ( If is current class or is subclass of ) this case is solved.

Tests are OK.
