### PR TITLE
Fixed incorrect passing of metadata cache instance to metadata factory service

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -94,7 +94,9 @@
         
         <service id="security.extra.metadata_factory" class="%security.extra.metadata_factory.class%" public="false">
             <argument type="service" id="security.extra.lazy_loading_driver" />
-            <argument type="service" id="security.extra.file_cache" />
+            <call method="setCache">
+                <argument type="service" id="security.extra.file_cache"/>
+            </call>
             <call method="setIncludeInterfaces">
                 <argument>true</argument>
             </call>


### PR DESCRIPTION
[`MetadataFactory`](https://github.com/schmittjoh/metadata/blob/master/src/Metadata/MetadataFactory.php) used by this bundle can cache collected metadata information but [service configuration](https://github.com/schmittjoh/JMSSecurityExtraBundle/blob/master/Resources/config/services.xml#L95) for it is incorrect - it passes cache as constructor argument while `MetadataFactory` expects it to be passed as [separate method call](https://github.com/schmittjoh/metadata/blob/master/src/Metadata/MetadataFactory.php#L55).

Because of this incompatibility current version of bundle actually never uses cache for classes metadata.
