### PR TITLE
Upgrade to Symfony 2.6+ and fix deprecation warnings

### DIFF
--- a/Resources/config/security_expressions.xml
+++ b/Resources/config/security_expressions.xml
@@ -27,7 +27,7 @@
 
     <services>
         <service id="security.extra.twig_extension" class="%security.extra.twig_extension.class%" public="false">
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.authorization_checker" />
             <tag name="twig.extension" alias="jms_security_extra" />
         </service>
     

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -37,7 +37,7 @@
     
         <service id="security.access.method_interceptor" class="%security.access.method_interceptor.class%">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="security.access.decision_manager" />
             <argument type="service" id="security.access.after_invocation_manager" />

--- a/Security/Authorization/Interception/MethodSecurityInterceptor.php
+++ b/Security/Authorization/Interception/MethodSecurityInterceptor.php
@@ -30,7 +30,7 @@ use Metadata\MetadataFactoryInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
@@ -42,7 +42,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
 class MethodSecurityInterceptor implements MethodInterceptorInterface
 {
     private $alwaysAuthenticate;
-    private $securityContext;
+    private $tokenStorage;
     private $metadataFactory;
     private $authenticationManager;
     private $accessDecisionManager;
@@ -50,11 +50,11 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
     private $runAsManager;
     private $logger;
 
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager,
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager,
                                 AfterInvocationManagerInterface $afterInvocationManager, RunAsManagerInterface $runAsManager, MetadataFactoryInterface $metadataFactory, LoggerInterface $logger = null)
     {
         $this->alwaysAuthenticate = false;
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->metadataFactory = $metadataFactory;
         $this->authenticationManager = $authenticationManager;
         $this->accessDecisionManager = $accessDecisionManager;
@@ -78,15 +78,15 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
         }
         $metadata = $metadata->methodMetadata[$method->reflection->name];
 
-        if (null === $token = $this->securityContext->getToken()) {
+        if (null === $token = $this->tokenStorage->getToken()) {
             throw new AuthenticationCredentialsNotFoundException(
-                'The security context was not populated with a Token.'
+                'The security token storage was not populated with a Token.'
             );
         }
 
         if ($this->alwaysAuthenticate || !$token->isAuthenticated()) {
             $token = $this->authenticationManager->authenticate($token);
-            $this->securityContext->setToken($token);
+            $this->tokenStorage->setToken($token);
         }
 
         if (!empty($metadata->roles) && false === $this->accessDecisionManager->decide($token, $metadata->roles, $method)) {
@@ -106,14 +106,14 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
             $runAsToken = $this->runAsManager->buildRunAs($token, $method, $metadata->runAsRoles);
 
             if (null !== $this->logger) {
-                $this->logger->debug('Populating security context with RunAsToken');
+                $this->logger->debug('Populating security token storage with RunAsToken');
             }
 
             if (null === $runAsToken) {
                 throw new RuntimeException('RunAsManager must not return null from buildRunAs().');
             }
 
-            $this->securityContext->setToken($runAsToken);
+            $this->tokenStorage->setToken($runAsToken);
         }
 
         try {
@@ -127,7 +127,7 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
                 return $returnValue;
             }
 
-            return $this->afterInvocationManager->decide($this->securityContext->getToken(), $method, $metadata->returnPermissions, $returnValue);
+            return $this->afterInvocationManager->decide($this->tokenStorage->getToken(), $method, $metadata->returnPermissions, $returnValue);
         } catch (\Exception $failed) {
             if (null !== $runAsToken) {
                 $this->restoreOriginalToken($runAsToken);
@@ -140,9 +140,9 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
     private function restoreOriginalToken(RunAsUserToken $runAsToken)
     {
         if (null !== $this->logger) {
-            $this->logger->debug('Populating security context with original Token.');
+            $this->logger->debug('Populating security token storage with original Token.');
         }
 
-        $this->securityContext->setToken($runAsToken->getOriginalToken());
+        $this->tokenStorage->setToken($runAsToken->getOriginalToken());
     }
 }

--- a/Twig/SecurityExtension.php
+++ b/Twig/SecurityExtension.php
@@ -3,15 +3,15 @@
 namespace JMS\SecurityExtraBundle\Twig;
 
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class SecurityExtension extends \Twig_Extension
 {
-    private $context;
+    private $checker;
 
-    public function __construct(SecurityContextInterface $context)
+    public function __construct(AuthorizationCheckerInterface $checker)
     {
-        $this->context = $context;
+        $this->checker = $checker;
     }
 
     public function getFunctions()
@@ -23,7 +23,7 @@ class SecurityExtension extends \Twig_Extension
 
     public function isExprGranted($expr, $object = null)
     {
-        return $this->context->isGranted(array(new Expression($expr)), $object);
+        return $this->checker->isGranted(array(new Expression($expr)), $object);
     }
 
     public function getName()


### PR DESCRIPTION
According to the [Symfony Roadmap](http://symfony.com/roadmap#checker), Symfony 2.5 is no longer supported as of July 2015. The next version 2.6 will be supported until January 2016.

See https://github.com/symfony/symfony/blob/2.6/UPGRADE-2.6.md#security

The `SecurityContextInterface` is marked as deprecated. The new `AuthorizationCheckerInterface` and `TokenStorageInterface` should be used instead.

These commits does not introduce new code.
These commits should be compatible with Symfony 2.7 as well.