### PR TITLE
SecurityContext deprecated from symfony 2.6

### DIFF
--- a/Resources/config/security_expressions.xml
+++ b/Resources/config/security_expressions.xml
@@ -27,7 +27,7 @@
 
     <services>
         <service id="security.extra.twig_extension" class="%security.extra.twig_extension.class%" public="false">
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.authorization_checker" />
             <tag name="twig.extension" alias="jms_security_extra" />
         </service>
     

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -37,7 +37,7 @@
     
         <service id="security.access.method_interceptor" class="%security.access.method_interceptor.class%">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="security.access.decision_manager" />
             <argument type="service" id="security.access.after_invocation_manager" />

--- a/Security/Authorization/Interception/MethodSecurityInterceptor.php
+++ b/Security/Authorization/Interception/MethodSecurityInterceptor.php
@@ -28,9 +28,9 @@ use JMS\SecurityExtraBundle\Security\Authorization\AfterInvocation\AfterInvocati
 use JMS\SecurityExtraBundle\Security\Authorization\RunAsManagerInterface;
 use Metadata\MetadataFactoryInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
@@ -42,7 +42,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
 class MethodSecurityInterceptor implements MethodInterceptorInterface
 {
     private $alwaysAuthenticate;
-    private $securityContext;
+    private $tokenStorage;
     private $metadataFactory;
     private $authenticationManager;
     private $accessDecisionManager;
@@ -50,11 +50,11 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
     private $runAsManager;
     private $logger;
 
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager,
+    public function __construct(TokenStorage $tokenStorage, AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager,
                                 AfterInvocationManagerInterface $afterInvocationManager, RunAsManagerInterface $runAsManager, MetadataFactoryInterface $metadataFactory, LoggerInterface $logger = null)
     {
         $this->alwaysAuthenticate = false;
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->metadataFactory = $metadataFactory;
         $this->authenticationManager = $authenticationManager;
         $this->accessDecisionManager = $accessDecisionManager;
@@ -78,7 +78,7 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
         }
         $metadata = $metadata->methodMetadata[$method->reflection->name];
 
-        if (null === $token = $this->securityContext->getToken()) {
+        if (null === $token = $this->tokenStorage->getToken()) {
             throw new AuthenticationCredentialsNotFoundException(
                 'The security context was not populated with a Token.'
             );
@@ -86,7 +86,7 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
 
         if ($this->alwaysAuthenticate || !$token->isAuthenticated()) {
             $token = $this->authenticationManager->authenticate($token);
-            $this->securityContext->setToken($token);
+            $this->tokenStorage->setToken($token);
         }
 
         if (!empty($metadata->roles) && false === $this->accessDecisionManager->decide($token, $metadata->roles, $method)) {
@@ -113,7 +113,7 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
                 throw new RuntimeException('RunAsManager must not return null from buildRunAs().');
             }
 
-            $this->securityContext->setToken($runAsToken);
+            $this->tokenStorage->setToken($runAsToken);
         }
 
         try {
@@ -127,7 +127,7 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
                 return $returnValue;
             }
 
-            return $this->afterInvocationManager->decide($this->securityContext->getToken(), $method, $metadata->returnPermissions, $returnValue);
+            return $this->afterInvocationManager->decide($this->tokenStorage->getToken(), $method, $metadata->returnPermissions, $returnValue);
         } catch (\Exception $failed) {
             if (null !== $runAsToken) {
                 $this->restoreOriginalToken($runAsToken);
@@ -143,6 +143,6 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
             $this->logger->debug('Populating security context with original Token.');
         }
 
-        $this->securityContext->setToken($runAsToken->getOriginalToken());
+        $this->tokenStorage->setToken($runAsToken->getOriginalToken());
     }
 }

--- a/Security/Authorization/Interception/MethodSecurityInterceptor.php
+++ b/Security/Authorization/Interception/MethodSecurityInterceptor.php
@@ -28,7 +28,7 @@ use JMS\SecurityExtraBundle\Security\Authorization\AfterInvocation\AfterInvocati
 use JMS\SecurityExtraBundle\Security\Authorization\RunAsManagerInterface;
 use Metadata\MetadataFactoryInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -50,7 +50,7 @@ class MethodSecurityInterceptor implements MethodInterceptorInterface
     private $runAsManager;
     private $logger;
 
-    public function __construct(TokenStorage $tokenStorage, AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager,
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager,
                                 AfterInvocationManagerInterface $afterInvocationManager, RunAsManagerInterface $runAsManager, MetadataFactoryInterface $metadataFactory, LoggerInterface $logger = null)
     {
         $this->alwaysAuthenticate = false;

--- a/Twig/SecurityExtension.php
+++ b/Twig/SecurityExtension.php
@@ -18,7 +18,7 @@ class SecurityExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'is_expr_granted' => new \Twig_Function_Method($this, 'isExprGranted'),
+            'is_expr_granted' => new \Twig_SimpleFunction('is_expr_granted', [$this, 'isExprGranted']),
         );
     }
 

--- a/Twig/SecurityExtension.php
+++ b/Twig/SecurityExtension.php
@@ -3,15 +3,16 @@
 namespace JMS\SecurityExtraBundle\Twig;
 
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
+
 
 class SecurityExtension extends \Twig_Extension
 {
-    private $context;
+    private $authorizationChecker;
 
-    public function __construct(SecurityContextInterface $context)
+    public function __construct(AuthorizationChecker $authorizationChecker)
     {
-        $this->context = $context;
+        $this->authorizationChecker = $authorizationChecker;
     }
 
     public function getFunctions()
@@ -23,7 +24,7 @@ class SecurityExtension extends \Twig_Extension
 
     public function isExprGranted($expr, $object = null)
     {
-        return $this->context->isGranted(array(new Expression($expr)), $object);
+        return $this->authorizationChecker->isGranted(array(new Expression($expr)), $object);
     }
 
     public function getName()


### PR DESCRIPTION
Updated security component references to avoid deprecated usage http://symfony.com/blog/new-in-symfony-2-6-security-component-improvements