### PR TITLE
Change references to SecurityContextInterface to TokenStorageInterface and AuthorizationCheckerInterface as per Symfony 2.6

### DIFF
--- a/Twig/SecurityExtension.php
+++ b/Twig/SecurityExtension.php
@@ -3,13 +3,13 @@
 namespace JMS\SecurityExtraBundle\Twig;
 
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class SecurityExtension extends \Twig_Extension
 {
     private $context;
 
-    public function __construct(SecurityContextInterface $context)
+    public function __construct(AuthorizationCheckerInterface $context)
     {
         $this->context = $context;
     }


### PR DESCRIPTION
Since Symfony 2.6, the `SecurityContextInterface` has been deprecated in favor of the `TokenStorageInterface` and `AuthorizationCheckerInterface`.
This PR fixes that for this bundle.