### PR TITLE
Add a note about FQCN usage for Access Control via DI in documentation

### DIFF
--- a/Resources/doc/method_security_authorization.rst
+++ b/Resources/doc/method_security_authorization.rst
@@ -1,11 +1,11 @@
 Method Security Authorization
 -----------------------------
 Securing methods allows for the most fine-grained access control that Symfony2
-has to offer. 
+has to offer.
 
 Generally, you can secure all public, or protected methods which are non-static,
 and non-final. Private methods cannot be secured. You can also add metadata for
-abstract methods, or interfaces which will then be applied to their concrete 
+abstract methods, or interfaces which will then be applied to their concrete
 implementations automatically.
 
 Access Control via DI configuration
@@ -19,21 +19,23 @@ You can specify access control **expressions** in the DI configuration:
         method_access_control:
             ':loginAction$': 'isAnonymous()'
             'AcmeFooBundle:.*:deleteAction': 'hasRole("ROLE_ADMIN")'
-            '^MyNamespace\MyService::foo$': 'hasPermission(#user, "VIEW")' 
+            '^MyNamespace\\MyService::foo$': 'hasPermission(#user, "VIEW")'
 
 The pattern is a case-sensitive regular expression which is matched against two notations.
 The first match is being used.
 
-First, your pattern is matched against the notation for non-service controllers. 
-This obviously is only done if your class is actually a controller, e.g. 
-``AcmeFooBundle:Add:new`` for a controller named ``AddController`` and a method 
-named ``newAction`` in a sub-namespace ``Controller`` in a bundle named ``AcmeFooBundle``. 
+First, your pattern is matched against the notation for non-service controllers.
+This obviously is only done if your class is actually a controller, e.g.
+``AcmeFooBundle:Add:new`` for a controller named ``AddController`` and a method
+named ``newAction`` in a sub-namespace ``Controller`` in a bundle named ``AcmeFooBundle``.
 
 Last, your pattern is matched against the concatenation of the class name, and
 the method name that is being called, e.g. ``My\Fully\Qualified\ClassName::myMethodName``.
 
-**Note:** If you would like to secure non-service controllers, the 
+**Note:** If you would like to secure non-service controllers, the
 ``JMSDiExtraBundle`` must be installed.
+
+**Note 2:** When using Fully Qualified Class Name, you have to escape backslashes as in example above.
 
 Access Control via Annotations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -43,7 +45,7 @@ configuration for this service:
 .. configuration-block ::
 
     .. code-block :: yaml
-    
+
         services:
             foo:
                 class: Bar
@@ -54,8 +56,8 @@ configuration for this service:
         <service id="foo" class="Bar">
             <tag name="security.secure_service"/>
         </service>
-        
+
 
 In case, you like to configure all services via annotations, you can also set
-``secure_all_services`` to true. Then, you do not need to add a tag for each 
+``secure_all_services`` to true. Then, you do not need to add a tag for each
 service.


### PR DESCRIPTION
I've added a note in the documentation to highlight the fact that backslashes have to be escaped when using FQCN in method_access_control patterns.
Otherwise, the comparison using preg_match fails.