### PR TITLE
Temporary fix for #207 when in dev mode.

### DIFF
--- a/Security/Authorization/RememberingAccessDecisionManager.php
+++ b/Security/Authorization/RememberingAccessDecisionManager.php
@@ -4,6 +4,7 @@ namespace JMS\SecurityExtraBundle\Security\Authorization;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
  * An introspectable access decision manager.
@@ -20,6 +21,15 @@ class RememberingAccessDecisionManager implements AccessDecisionManagerInterface
         $this->delegate = $delegate;
     }
 
+    /**
+     * Get arguments of last call to "Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface::decide" method.
+     *
+     * Purpose of this method is to allow custom access denied handler to access arguments which lead to denial of access
+     * and to, per example, redirect to custom page or execute custom action based on those arguments to rectify made decision.
+     *
+     * @return array        Arguments of last call to "Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface::decide" method,
+     *                      array(0 => TokenInterface $token, 1 => array $attributes, 2 => $object = null).
+     */
     public function getLastDecisionCall()
     {
         return $this->lastDecisionCall;
@@ -39,6 +49,20 @@ class RememberingAccessDecisionManager implements AccessDecisionManagerInterface
         $this->lastDecisionCall = array($token, $attributes, $object);
 
         return $this->delegate->decide($token, $attributes, $object);
+    }
+
+    /**
+     * Configures the voters.
+     *
+     * @param VoterInterface[] $voters An array of VoterInterface instances
+     */
+    public function setVoters(array $voters)
+    {
+        if (!method_exists($this->delegate, 'setVoters')) {
+            throw new \RuntimeException(sprintf('Decorated implementation of "%s", instance of class "%s" does not have "setVoters" which is required for development environment.', AccessDecisionManagerInterface::class, get_class($this->delegate)));
+        }
+
+        $this->delegate->setVoters($voters);
     }
 
     /**


### PR DESCRIPTION
While you all agree (Johan, SF community, whoever...) how to deal with incompatibility issue between this bundle and Symfony's security component, we are still experiencing issues when using this bundle in 'dev' mode.

So, this fix will not replace Symfony's default access decision manager when in debug mode, and since JMS's ADM is only performance boost, which we are not seeking for in debug mode, guess there are more benefits for us to have this patch ASAP, and you can, of course, remove it when proper solution is provided.

Until then - simple "off" button to 'RememberingAccessDecisionManager' in dev mode is just fine.