### PR TITLE
Dont call addClassesToCompile on PHP 7.0, its deprecated

### DIFF
--- a/DependencyInjection/SecurityExtension.php
+++ b/DependencyInjection/SecurityExtension.php
@@ -88,10 +88,12 @@ class SecurityExtension extends Extension
         if (!$config['access_control']) {
             return;
         }
-
-        $this->addClassesToCompile(array(
-            'Symfony\\Component\\Security\\Http\\AccessMap',
-        ));
+        
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'Symfony\\Component\\Security\\Http\\AccessMap',
+            ));
+        }
 
         foreach ($config['access_control'] as $access) {
             $matcher = $this->invokeParent('createRequestMatcher', array(


### PR DESCRIPTION
As `addClassesToCompile` is deprecated in Symfony, it should also be removed here. 

See https://github.com/symfony/symfony/issues/20668 for the discussion about deprecation.
See https://github.com/doctrine/DoctrineBundle/pull/608 for a similar PR on DoctrineBundle.

Fixes #218.