### PR TITLE
Replace usage of deprecated security.context in documentation

### DIFF
--- a/Resources/doc/expressions.rst
+++ b/Resources/doc/expressions.rst
@@ -23,10 +23,13 @@ of the SecurityContext. Some examples:
 
     use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 
-    $securityContext->isGranted(array(new Expression('hasRole("A")')));
-    $securityContext->isGranted(array(new Expression('hasRole("A") or (hasRole("B") and hasRole("C"))')));
-    $securityContext->isGranted(array(new Expression('hasPermission(object, "VIEW")')), $object);
-    $securityContext->isGranted(array(new Expression('token.getUsername() == "Johannes"')));
+    $authorizationChecker = $this->get('security.authorization_checker');
+    // Prior to Symfony 2.6 use 'security.context' instead of 'security.authorization_checker'
+
+    $authorizationChecker->isGranted(array(new Expression('hasRole("A")')));
+    $authorizationChecker->isGranted(array(new Expression('hasRole("A") or (hasRole("B") and hasRole("C"))')));
+    $authorizationChecker->isGranted(array(new Expression('hasPermission(object, "VIEW")')), $object);
+    $authorizationChecker->isGranted(array(new Expression('token.getUsername() == "Johannes"')));
 
 Twig Usage
 ~~~~~~~~~~


### PR DESCRIPTION
Hi @schmittjoh 

Here is a minor change to some old documentation I was referring to this week.

With the `security.context` service having been [deprecated](https://symfony.com/blog/new-in-symfony-2-6-security-component-improvements) in Symfony 2.6, this PR updates the example in the `expressions.rst` documentation to use the preferred `security.authorization_checker` service.