### PR TITLE
Rename String Class to Text Class for PHP7 compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 phpunit.xml
 vendor/
 composer.lock
+.idea/

--- a/Security/Util/Text.php
+++ b/Security/Util/Text.php
@@ -3,13 +3,11 @@
 namespace JMS\SecurityExtraBundle\Security\Util;
 
 /**
- * String utility functions.
- *
- * @deprecated This class will break in PHP 7; use hash_equals() instead
+ * Text utility functions.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-final class String
+final class Text
 {
     final private function __construct() {}
 

--- a/Tests/DependencyInjection/Compiler/AddAfterInvocationProvidersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddAfterInvocationProvidersPassTest.php
@@ -18,11 +18,12 @@
 
 namespace JMS\SecurityExtraBundle\Tests\DependencyInjection\Compiler;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Definition;
 use JMS\SecurityExtraBundle\DependencyInjection\Compiler\AddAfterInvocationProvidersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class AddAfterInvocationProvidersPassTest extends \PHPUnit_Framework_TestCase
+class AddAfterInvocationProvidersPassTest extends TestCase
 {
     public function testProcessStopsWhenNoAfterInvocationManager()
     {

--- a/Tests/DependencyInjection/Compiler/CollectSecuredServicesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CollectSecuredServicesPassTest.php
@@ -18,11 +18,12 @@
 
 namespace JMS\SecurityExtraBundle\Tests\DependencyInjection\Compiler;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 use JMS\SecurityExtraBundle\DependencyInjection\Compiler\CollectSecuredServicesPass;
 
-class CollectSecuredServicesPassTest extends \PHPUnit_Framework_TestCase
+class CollectSecuredServicesPassTest extends TestCase
 {
     public function testProcess()
     {

--- a/Tests/DependencyInjection/JMSSecurityExtraExtensionTest.php
+++ b/Tests/DependencyInjection/JMSSecurityExtraExtensionTest.php
@@ -18,10 +18,11 @@
 
 namespace JMS\SecurityExtraBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use JMS\SecurityExtraBundle\DependencyInjection\JMSSecurityExtraExtension;
 
-class JMSSecurityExtraExtensionTest extends \PHPUnit_Framework_TestCase
+class JMSSecurityExtraExtensionTest extends TestCase
 {
     private $extension;
 

--- a/Tests/Metadata/ClassMetadataTest.php
+++ b/Tests/Metadata/ClassMetadataTest.php
@@ -23,8 +23,9 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\SecurityExtraBundle\Metadata\Driver\AnnotationDriver;
 
 use Metadata\MetadataFactory;
+use PHPUnit\Framework\TestCase;
 
-class ClassMetadataTest extends \PHPUnit_Framework_TestCase
+class ClassMetadataTest extends TestCase
 {
     /**
     * @expectedException \RuntimeException

--- a/Tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/Tests/Metadata/Driver/AnnotationDriverTest.php
@@ -21,10 +21,11 @@ namespace JMS\SecurityExtraBundle\Tests\Mapping\Driver;
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 use JMS\SecurityExtraBundle\Metadata\Driver\AnnotationDriver;
+use PHPUnit\Framework\TestCase;
 
 require_once __DIR__.'/Fixtures/services.php';
 
-class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
+class AnnotationDriverTest extends TestCase
 {
     public function testLoadMetadataWithClassPreAuthorize()
     {

--- a/Tests/Metadata/Driver/ConfigDriverTest.php
+++ b/Tests/Metadata/Driver/ConfigDriverTest.php
@@ -5,8 +5,9 @@ namespace JMS\SecurityExtraBundle\Tests\Metadata\Driver;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 use JMS\SecurityExtraBundle\Metadata\MethodMetadata;
 use JMS\SecurityExtraBundle\Metadata\Driver\ConfigDriver;
+use PHPUnit\Framework\TestCase;
 
-class ConfigDriverTest extends \PHPUnit_Framework_TestCase
+class ConfigDriverTest extends TestCase
 {
     public function testLoadMetadata()
     {

--- a/Tests/Security/Acl/Expression/HasClassPermissionFunctionCompilerTest.php
+++ b/Tests/Security/Acl/Expression/HasClassPermissionFunctionCompilerTest.php
@@ -7,8 +7,9 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\VariableExpres
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\ConstantExpression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\FunctionExpression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionCompiler;
+use PHPUnit\Framework\TestCase;
 
-class HasClassPermissionFunctionCompilerTest extends \PHPUnit_Framework_TestCase
+class HasClassPermissionFunctionCompilerTest extends TestCase
 {
     private $compiler;
 

--- a/Tests/Security/Acl/Expression/HasPermissionFunctionCompilerTest.php
+++ b/Tests/Security/Acl/Expression/HasPermissionFunctionCompilerTest.php
@@ -7,8 +7,9 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\VariableExpres
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\ConstantExpression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\FunctionExpression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionCompiler;
+use PHPUnit\Framework\TestCase;
 
-class HasPermissionFunctionCompilerTest extends \PHPUnit_Framework_TestCase
+class HasPermissionFunctionCompilerTest extends TestCase
 {
     private $compiler;
 

--- a/Tests/Security/Acl/Expression/PermissionEvaluatorTest.php
+++ b/Tests/Security/Acl/Expression/PermissionEvaluatorTest.php
@@ -2,13 +2,14 @@
 
 namespace JMS\SecurityExtraBundle\Tests\Security\Acl\Expression;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
 
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
 
 use JMS\SecurityExtraBundle\Security\Acl\Expression\PermissionEvaluator;
 
-class PermissionEvaluatorTest extends \PHPUnit_Framework_TestCase
+class PermissionEvaluatorTest extends TestCase
 {
     private $token;
     private $object;

--- a/Tests/Security/Acl/Voter/AclVoterTest.php
+++ b/Tests/Security/Acl/Voter/AclVoterTest.php
@@ -2,6 +2,7 @@
 
 namespace JMS\SecurityExtraBundle\Tests\Security\Acl\Voter;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
@@ -11,7 +12,7 @@ use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use JMS\SecurityExtraBundle\Security\Acl\Voter\AclVoter;
 
-class AclVoterTest extends \PHPUnit_Framework_TestCase
+class AclVoterTest extends TestCase
 {
     /**
      * @dataProvider getSupportsAttributeTests

--- a/Tests/Security/Authentication/Provider/RunAsAuthenticationProviderTest.php
+++ b/Tests/Security/Authentication/Provider/RunAsAuthenticationProviderTest.php
@@ -21,8 +21,9 @@ namespace JMS\SecurityExtraBundle\Tests\Security\Authentication\Provider;
 use JMS\SecurityExtraBundle\Security\Authentication\Token\RunAsUserToken;
 
 use JMS\SecurityExtraBundle\Security\Authentication\Provider\RunAsAuthenticationProvider;
+use PHPUnit\Framework\TestCase;
 
-class RunAsAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
+class RunAsAuthenticationProviderTest extends TestCase
 {
     public function testAuthenticateReturnsNullIfTokenISUnsupported()
     {

--- a/Tests/Security/Authentication/Token/RunAsUserTokenTest.php
+++ b/Tests/Security/Authentication/Token/RunAsUserTokenTest.php
@@ -18,12 +18,13 @@
 
 namespace JMS\SecurityExtraBundle\Tests\Security\Authentication\Token;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 use Symfony\Component\Security\Core\Role\Role;
 use JMS\SecurityExtraBundle\Security\Authentication\Token\RunAsUserToken;
 
-class RunAsUserTokenTest extends \PHPUnit_Framework_TestCase
+class RunAsUserTokenTest extends TestCase
 {
     public function testConstructor()
     {

--- a/Tests/Security/Authorization/AfterInvocation/AclAfterInvocationProviderTest.php
+++ b/Tests/Security/Authorization/AfterInvocation/AclAfterInvocationProviderTest.php
@@ -18,13 +18,14 @@
 
 namespace JMS\SecurityExtraBundle\Tests\Security\Authorization\AfterInvocation;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
 
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use JMS\SecurityExtraBundle\Security\Authorization\AfterInvocation\AclAfterInvocationProvider;
 
-class AclAfterInvocationProviderTest extends \PHPUnit_Framework_TestCase
+class AclAfterInvocationProviderTest extends TestCase
 {
     public function testDecideReturnsNullWhenObjectIsNull()
     {

--- a/Tests/Security/Authorization/AfterInvocation/AfterInvocationManagerTest.php
+++ b/Tests/Security/Authorization/AfterInvocation/AfterInvocationManagerTest.php
@@ -19,8 +19,9 @@
 namespace JMS\SecurityExtraBundle\Tests\Security\Authorization\AfterInvocation;
 
 use JMS\SecurityExtraBundle\Security\Authorization\AfterInvocation\AfterInvocationManager;
+use PHPUnit\Framework\TestCase;
 
-class AfterInvocationManagerTest extends \PHPUnit_Framework_TestCase
+class AfterInvocationManagerTest extends TestCase
 {
     public function testDecide()
     {

--- a/Tests/Security/Authorization/Expression/ExpressionCompilerTest.php
+++ b/Tests/Security/Authorization/Expression/ExpressionCompilerTest.php
@@ -12,11 +12,12 @@ use JMS\SecurityExtraBundle\Tests\Security\Authorization\Expression\Fixture\Issu
 
 use JMS\SecurityExtraBundle\Tests\Security\Authorization\Expression\Fixture\Issue22\SecuredObject;
 use CG\Proxy\MethodInvocation;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Role\Role;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionCompiler;
 
-class ExpressionCompilerTest extends \PHPUnit_Framework_TestCase
+class ExpressionCompilerTest extends TestCase
 {
     private $compiler;
 

--- a/Tests/Security/Authorization/Expression/ExpressionLexerTest.php
+++ b/Tests/Security/Authorization/Expression/ExpressionLexerTest.php
@@ -3,8 +3,9 @@
 namespace JMS\SecurityExtraBundle\Tests\Security\Authorization\Expression;
 
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionLexer;
+use PHPUnit\Framework\TestCase;
 
-class ExpressionLexerTest extends \PHPUnit_Framework_TestCase
+class ExpressionLexerTest extends TestCase
 {
     private $lexer;
 

--- a/Tests/Security/Authorization/Expression/ExpressionParserTest.php
+++ b/Tests/Security/Authorization/Expression/ExpressionParserTest.php
@@ -14,8 +14,9 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\OrExpression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\AndExpression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\FunctionExpression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionParser;
+use PHPUnit\Framework\TestCase;
 
-class ExpressionParserTest extends \PHPUnit_Framework_TestCase
+class ExpressionParserTest extends TestCase
 {
     private $parser;
 

--- a/Tests/Security/Authorization/Expression/ExpressionVoterTest.php
+++ b/Tests/Security/Authorization/Expression/ExpressionVoterTest.php
@@ -3,6 +3,7 @@
 namespace JMS\SecurityExtraBundle\Tests\Security\Authorization\Expression;
 
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\DefaultExpressionHandler;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Role\Role;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionCompiler;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
@@ -11,7 +12,7 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 use Symfony\Component\Filesystem\Filesystem;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionVoter;
 
-class ExpressionVoterTest extends \PHPUnit_Framework_TestCase
+class ExpressionVoterTest extends TestCase
 {
     private $voter;
     private $cacheDir;

--- a/Tests/Security/Authorization/Expression/ParameterExpressionCompilerTest.php
+++ b/Tests/Security/Authorization/Expression/ParameterExpressionCompilerTest.php
@@ -22,8 +22,9 @@ use CG\Proxy\MethodInvocation;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Compiler\ParameterExpressionCompiler;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionCompiler;
+use PHPUnit\Framework\TestCase;
 
-class ParameterExpressionCompilerTest extends \PHPUnit_Framework_TestCase
+class ParameterExpressionCompilerTest extends TestCase
 {
     private $compiler;
 

--- a/Tests/Security/Authorization/Expression/ReverseInterpreterTest.php
+++ b/Tests/Security/Authorization/Expression/ReverseInterpreterTest.php
@@ -5,12 +5,13 @@ namespace JMS\SecurityExtraBundle\Tests\Security\Authorization\Expression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\OrExpression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Ast\VariableExpression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ReverseInterpreter;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionCompiler;
 
-class ReverseInterpreterTest extends \PHPUnit_Framework_TestCase
+class ReverseInterpreterTest extends TestCase
 {
     private $compiler;
     private $reverseInterpreter;

--- a/Tests/Security/Authorization/Expression/VariableExpressionCompilerTest.php
+++ b/Tests/Security/Authorization/Expression/VariableExpressionCompilerTest.php
@@ -20,8 +20,9 @@ namespace JMS\SecurityExtraBundle\Tests\Security\Authorization\Expression;
 
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\ExpressionCompiler;
+use PHPUnit\Framework\TestCase;
 
-class VariableExpressionCompilerTest extends \PHPUnit_Framework_TestCase
+class VariableExpressionCompilerTest extends TestCase
 {
     private $compiler;
 

--- a/Tests/Security/Authorization/Interception/MethodSecurityInterceptorTest.php
+++ b/Tests/Security/Authorization/Interception/MethodSecurityInterceptorTest.php
@@ -26,11 +26,12 @@ use JMS\SecurityExtraBundle\Metadata\ClassMetadata;
 use Metadata\MetadataFactoryInterface;
 
 use JMS\SecurityExtraBundle\Security\Authentication\Token\RunAsUserToken;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use JMS\SecurityExtraBundle\Security\Authorization\Interception\MethodSecurityInterceptor;
 use CG\Proxy\MethodInvocation;
 
-class MethodSecurityInterceptorTest extends \PHPUnit_Framework_TestCase
+class MethodSecurityInterceptorTest extends TestCase
 {
     /**
      * @expectedException Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException

--- a/Tests/Security/Authorization/Interception/SecurityPointcutTest.php
+++ b/Tests/Security/Authorization/Interception/SecurityPointcutTest.php
@@ -3,8 +3,9 @@
 namespace JMS\SecurityExtraBundle\Tests\Security\Authorization\Interception;
 
 use JMS\SecurityExtraBundle\Security\Authorization\Interception\SecurityPointcut;
+use PHPUnit\Framework\TestCase;
 
-class SecurityPointcutTest extends \PHPUnit_Framework_TestCase
+class SecurityPointcutTest extends TestCase
 {
     private $metadataFactory;
 

--- a/Tests/Security/Authorization/RememberingAccessDecisionManagerTest.php
+++ b/Tests/Security/Authorization/RememberingAccessDecisionManagerTest.php
@@ -3,8 +3,9 @@
 namespace JMS\SecurityExtraBundle\Tests\Security\Authorization;
 
 use JMS\SecurityExtraBundle\Security\Authorization\RememberingAccessDecisionManager;
+use PHPUnit\Framework\TestCase;
 
-class RememberingAccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
+class RememberingAccessDecisionManagerTest extends TestCase
 {
     private $adm;
     private $delegate;

--- a/Tests/Security/Authorization/Voter/IddqdVoterTest.php
+++ b/Tests/Security/Authorization/Voter/IddqdVoterTest.php
@@ -3,9 +3,10 @@
 namespace JMS\SecurityExtraBundle\Tests\Security\Authorization\Voter;
 
 use JMS\SecurityExtraBundle\Security\Authorization\Voter\IddqdVoter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class IddqdVoterTest extends \PHPUnit_Framework_TestCase
+class IddqdVoterTest extends TestCase
 {
     public function testRoleIddqd()
     {

--- a/Tests/Security/Util/SecureRandomTest.php
+++ b/Tests/Security/Util/SecureRandomTest.php
@@ -7,8 +7,9 @@ use Psr\Log\NullLogger;
 use JMS\SecurityExtraBundle\Security\Util\SecureRandomSchema;
 use Doctrine\DBAL\DriverManager;
 use JMS\SecurityExtraBundle\Security\Util\SecureRandom;
+use PHPUnit\Framework\TestCase;
 
-class SecureRandomTest extends \PHPUnit_Framework_TestCase
+class SecureRandomTest extends TestCase
 {
     /**
      * T1: Monobit test

--- a/Tests/Security/Util/StringTest.php
+++ b/Tests/Security/Util/StringTest.php
@@ -2,16 +2,13 @@
 
 namespace JMS\SecurityExtraBundle\Tests\Security\Util;
 
-use JMS\SecurityExtraBundle\Security\Util\String as StringUtil;
+use JMS\SecurityExtraBundle\Security\Util\Text as TextUtil;
 
 class StringTest extends \PHPUnit_Framework_TestCase
 {
     public function testEquals()
     {
-        if(PHP_VERSION_ID >= 70000) {
-            return $this->markTestSkipped('String class name can\'t be used on php 7.');
-        }
-        $this->assertTrue(StringUtil::equals('password', 'password'));
-        $this->assertFalse(StringUtil::equals('password', 'foo'));
+        $this->assertTrue(TextUtil::equals('password', 'password'));
+        $this->assertFalse(TextUtil::equals('password', 'foo'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "doctrine/common": "~2.3",
         "symfony/form": "~2.2|~3.0",
         "symfony/validator": "~2.2|~3.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "phpunit/phpunit": "^6"
     },
     "autoload": {
         "psr-4": { "JMS\\SecurityExtraBundle\\": "" }


### PR DESCRIPTION
String is a reserved name in PHP 7*